### PR TITLE
Multiple receivers this labels review

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/AccessorForPropertyDescriptor.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/AccessorForPropertyDescriptor.kt
@@ -98,7 +98,7 @@ open class AccessorForPropertyDescriptor private constructor(
     init {
         setType(
             propertyType, emptyList<TypeParameterDescriptorImpl>(), dispatchReceiverParameter,
-            DescriptorFactory.createExtensionReceiverParameterForCallable(this, receiverType, Annotations.EMPTY),
+            DescriptorFactory.createExtensionReceiverParameterForCallable(this, receiverType, Annotations.EMPTY, false),
             emptyList() // TODO
         )
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
@@ -719,9 +719,10 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
             val result = HashSet<String>()
 
             if (lambdaOrFun != null) {
-                val label = LabelResolver.getLabelNameIfAny(lambdaOrFun)
-                if (label != null) {
-                    result.add(label.asString())
+                // TODO: Do we need to add additional receiver names here?
+                val labels = LabelResolver.getLabelNamesIfAny(lambdaOrFun, addAdditionalReceiverNames = false)
+                if (labels.singleOrNull() != null) {
+                    result.add(labels.single().asString())
                 }
             }
 

--- a/compiler/fir/analysis-tests/tests/org/jetbrains/kotlin/fir/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests/org/jetbrains/kotlin/fir/FirOldFrontendDiagnosticsTestGenerated.java
@@ -8137,6 +8137,37 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirOldFronte
             runTest("compiler/testData/diagnostics/tests/extensions/variableInvoke.kt");
         }
 
+        @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractFirOldFrontendDiagnosticsTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), Pattern.compile("^(.+)\\.fir\\.kts?$"), true);
+            }
+
+            @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class Functions extends AbstractFirOldFrontendDiagnosticsTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInFunctions() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions"), Pattern.compile("^(.+)\\.kt$"), Pattern.compile("^(.+)\\.fir\\.kts?$"), true);
+                }
+
+                @TestMetadata("simple.kt")
+                public void testSimple() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions/simple.kt");
+                }
+            }
+        }
+
         @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -8170,6 +8201,16 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirOldFronte
                 public void testOuterClass() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/outerClass.kt");
                 }
+
+                @TestMetadata("superWithContext.kt")
+                public void testSuperWithContext() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.kt");
+                }
+
+                @TestMetadata("thisWithReceiverLabels.kt")
+                public void testThisWithReceiverLabels() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.kt");
+                }
             }
 
             @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions")
@@ -8189,6 +8230,11 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirOldFronte
                     runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/insideDeclaration.kt");
                 }
 
+                @TestMetadata("manyReceivers.kt")
+                public void testManyReceivers() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/manyReceivers.kt");
+                }
+
                 @TestMetadata("noExplicitReceiver.kt")
                 public void testNoExplicitReceiver() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/noExplicitReceiver.kt");
@@ -8197,6 +8243,21 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirOldFronte
                 @TestMetadata("plusMatrix.kt")
                 public void testPlusMatrix() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/plusMatrix.kt");
+                }
+
+                @TestMetadata("resolutionFailure.kt")
+                public void testResolutionFailure() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/resolutionFailure.kt");
+                }
+
+                @TestMetadata("thisIdentifierInfo.kt")
+                public void testThisIdentifierInfo() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.kt");
+                }
+
+                @TestMetadata("thisWithReceiverLabels.kt")
+                public void testThisWithReceiverLabels() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.kt");
                 }
 
                 @TestMetadata("typeParameterized.kt")
@@ -8235,6 +8296,11 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirOldFronte
                 @TestMetadata("dp.kt")
                 public void testDp() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/dp.kt");
+                }
+
+                @TestMetadata("thisWithReceiverLabels.kt")
+                public void testThisWithReceiverLabels() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.kt");
                 }
             }
         }

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -11650,6 +11650,29 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractFirBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.JVM_IR, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -11667,14 +11690,39 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/JavaSyntheticPropertiesScope.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/JavaSyntheticPropertiesScope.kt
@@ -333,7 +333,7 @@ class JavaSyntheticPropertiesScope(storageManager: StorageManager, private val l
                 val receiverType = typeSubstitutor.safeSubstitute(ownerClass.defaultType, Variance.INVARIANT)
                 descriptor.setType(
                     propertyType, typeParameters, null,
-                    DescriptorFactory.createExtensionReceiverParameterForCallable(descriptor, receiverType, Annotations.EMPTY),
+                    DescriptorFactory.createExtensionReceiverParameterForCallable(descriptor, receiverType, Annotations.EMPTY, false),
                     emptyList()
                 )
 

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContext.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContext.java
@@ -48,6 +48,8 @@ import org.jetbrains.kotlin.util.slicedMap.*;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.jetbrains.kotlin.util.slicedMap.RewritePolicy.DO_NOTHING;
 import static org.jetbrains.kotlin.util.slicedMap.Slices.COMPILE_TIME_VALUE_REWRITE_POLICY;
@@ -260,6 +262,7 @@ public interface BindingContext {
                     .setFurtherLookupSlices(DECLARATIONS_TO_DESCRIPTORS)
                     .build();
 
+    WritableSlice<DeclarationDescriptor, LinkedHashMap<ReceiverParameterDescriptor, String>> DESCRIPTOR_TO_NAMED_RECEIVERS = Slices.createSimpleSlice();
     WritableSlice<KtReferenceExpression, PsiElement> LABEL_TARGET = Slices.createSimpleSlice();
     WritableSlice<KtReferenceExpression, Collection<? extends PsiElement>> AMBIGUOUS_LABEL_TARGET = Slices.createSimpleSlice();
     WritableSlice<ValueParameterDescriptor, PropertyDescriptor> VALUE_PARAMETER_AS_PROPERTY = Slices.createSimpleSlice();

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContext.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContext.java
@@ -262,7 +262,7 @@ public interface BindingContext {
                     .setFurtherLookupSlices(DECLARATIONS_TO_DESCRIPTORS)
                     .build();
 
-    WritableSlice<DeclarationDescriptor, LinkedHashMap<ReceiverParameterDescriptor, String>> DESCRIPTOR_TO_NAMED_RECEIVERS = Slices.createSimpleSlice();
+    WritableSlice<DeclarationDescriptor, Map<ReceiverParameterDescriptor, String>> DESCRIPTOR_TO_NAMED_RECEIVERS = Slices.createSimpleSlice();
     WritableSlice<KtReferenceExpression, PsiElement> LABEL_TARGET = Slices.createSimpleSlice();
     WritableSlice<KtReferenceExpression, Collection<? extends PsiElement>> AMBIGUOUS_LABEL_TARGET = Slices.createSimpleSlice();
     WritableSlice<ValueParameterDescriptor, PropertyDescriptor> VALUE_PARAMETER_AS_PROPERTY = Slices.createSimpleSlice();

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/BodyResolver.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/BodyResolver.java
@@ -980,7 +980,8 @@ public class BodyResolver {
         }
 
         // Synthetic "field" creation
-        if (functionDescriptor instanceof PropertyAccessorDescriptor && functionDescriptor.getExtensionReceiverParameter() == null) {
+        if (functionDescriptor instanceof PropertyAccessorDescriptor && functionDescriptor.getExtensionReceiverParameter() == null
+            && functionDescriptor.getAdditionalReceiverParameters().isEmpty()) {
             PropertyAccessorDescriptor accessorDescriptor = (PropertyAccessorDescriptor) functionDescriptor;
             KtProperty property = (KtProperty) function.getParent();
             SyntheticFieldDescriptor fieldDescriptor = new SyntheticFieldDescriptor(accessorDescriptor, property);

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/DescriptorResolver.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/DescriptorResolver.java
@@ -953,7 +953,7 @@ public class DescriptorResolver {
 
         KtTypeReference receiverTypeRef = variableDeclaration.getReceiverTypeReference();
         List<KtTypeReference> additionalReceiverTypeRefs = variableDeclaration.getAdditionalReceiverTypeReferences();
-        LinkedHashMap<ReceiverParameterDescriptor, String> receiverToLabelMap = new LinkedHashMap<>();
+        Map<ReceiverParameterDescriptor, String> receiverToLabelMap = new LinkedHashMap<>();
         ReceiverParameterDescriptor receiverDescriptor =
                 receiverTypeRef == null
                 ? null

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/DescriptorResolver.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/DescriptorResolver.java
@@ -53,6 +53,7 @@ import org.jetbrains.kotlin.resolve.lazy.ForceResolveUtil;
 import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyTypeAliasDescriptor;
 import org.jetbrains.kotlin.resolve.scopes.*;
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver;
+import org.jetbrains.kotlin.resolve.scopes.receivers.ReceiverValue;
 import org.jetbrains.kotlin.resolve.scopes.receivers.TransientReceiver;
 import org.jetbrains.kotlin.resolve.scopes.utils.ScopeUtilsKt;
 import org.jetbrains.kotlin.resolve.source.KotlinSourceElementKt;
@@ -69,8 +70,7 @@ import java.util.stream.Stream;
 import static org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.*;
 import static org.jetbrains.kotlin.diagnostics.Errors.*;
 import static org.jetbrains.kotlin.lexer.KtTokens.*;
-import static org.jetbrains.kotlin.resolve.BindingContext.CONSTRUCTOR;
-import static org.jetbrains.kotlin.resolve.BindingContext.TYPE_ALIAS;
+import static org.jetbrains.kotlin.resolve.BindingContext.*;
 import static org.jetbrains.kotlin.resolve.DescriptorUtils.*;
 import static org.jetbrains.kotlin.resolve.ModifiersChecker.resolveMemberModalityFromModifiers;
 import static org.jetbrains.kotlin.resolve.ModifiersChecker.resolveVisibilityFromModifiers;
@@ -921,8 +921,6 @@ public class DescriptorResolver {
         List<TypeParameterDescriptorImpl> typeParameterDescriptors;
         LexicalScope scopeForDeclarationResolutionWithTypeParameters;
         LexicalScope scopeForInitializerResolutionWithTypeParameters;
-        KotlinType receiverType = null;
-        Stream<KotlinType> additionalReceiverTypes = Stream.empty();
 
         {
             List<KtTypeParameter> typeParameters = variableDeclaration.getTypeParameters();
@@ -951,34 +949,19 @@ public class DescriptorResolver {
                 scopeForDeclarationResolutionWithTypeParameters = writableScopeForDeclarationResolution;
                 scopeForInitializerResolutionWithTypeParameters = writableScopeForInitializerResolution;
             }
-
-            KtTypeReference receiverTypeRef = variableDeclaration.getReceiverTypeReference();
-            if (receiverTypeRef != null) {
-                receiverType = typeResolver.resolveType(scopeForDeclarationResolutionWithTypeParameters, receiverTypeRef, trace, true);
-            }
-
-            List<KtTypeReference> additionalReceiverTypeRefs = variableDeclaration.getAdditionalReceiverTypeReferences();
-            additionalReceiverTypes = additionalReceiverTypeRefs.stream()
-                    .map((typeRef) -> typeResolver.resolveType(scopeForDeclarationResolutionWithTypeParameters, typeRef, trace, true));
         }
 
-        ReceiverParameterDescriptor receiverDescriptor;
-        if (receiverType != null) {
-            AnnotationSplitter splitter = new AnnotationSplitter(storageManager, receiverType.getAnnotations(), EnumSet.of(RECEIVER));
-            receiverDescriptor = DescriptorFactory.createExtensionReceiverParameterForCallable(
-                    propertyDescriptor, receiverType, splitter.getAnnotationsForTarget(RECEIVER)
-            );
-        }
-        else {
-            receiverDescriptor = null;
-        }
-
-        List<ReceiverParameterDescriptor> additionalReceiverDescriptors = additionalReceiverTypes.map((type) -> {
-            AnnotationSplitter splitter = new AnnotationSplitter(storageManager, type.getAnnotations(), EnumSet.of(RECEIVER));
-            return DescriptorFactory.createExtensionReceiverParameterForCallable(
-                    propertyDescriptor, type, splitter.getAnnotationsForTarget(RECEIVER)
-            );
-        }).collect(Collectors.toList());
+        KtTypeReference receiverTypeRef = variableDeclaration.getReceiverTypeReference();
+        List<KtTypeReference> additionalReceiverTypeRefs = variableDeclaration.getAdditionalReceiverTypeReferences();
+        LinkedHashMap<ReceiverParameterDescriptor, String> receiverToLabelMap = new LinkedHashMap<>();
+        ReceiverParameterDescriptor receiverDescriptor =
+                receiverTypeRef == null
+                ? null
+                : createReceiverDescriptorsForProperty(propertyDescriptor, scopeForDeclarationResolutionWithTypeParameters, trace,
+                                                       Collections.singletonList(receiverTypeRef), receiverToLabelMap, false).get(0);
+        List<ReceiverParameterDescriptor> additionalReceiverDescriptors =
+                createReceiverDescriptorsForProperty(propertyDescriptor, scopeForDeclarationResolutionWithTypeParameters, trace,
+                                                     additionalReceiverTypeRefs, receiverToLabelMap, true);
 
         LexicalScope scopeForInitializer = ScopeUtils.makeScopeForPropertyInitializer(scopeForInitializerResolutionWithTypeParameters, propertyDescriptor);
         KotlinType propertyType = propertyInfo.getVariableType();
@@ -1023,9 +1006,39 @@ public class DescriptorResolver {
                 new FieldDescriptorImpl(annotationSplitter.getAnnotationsForTarget(FIELD), propertyDescriptor),
                 new FieldDescriptorImpl(annotationSplitter.getAnnotationsForTarget(PROPERTY_DELEGATE_FIELD), propertyDescriptor)
         );
-
+        trace.record(DESCRIPTOR_TO_NAMED_RECEIVERS, getter, receiverToLabelMap);
+        if (setter != null) {
+            trace.record(DESCRIPTOR_TO_NAMED_RECEIVERS, setter, receiverToLabelMap);
+        }
+        trace.record(DESCRIPTOR_TO_NAMED_RECEIVERS, propertyDescriptor, receiverToLabelMap);
         trace.record(BindingContext.VARIABLE, variableDeclaration, propertyDescriptor);
         return propertyDescriptor;
+    }
+
+    private List<ReceiverParameterDescriptor> createReceiverDescriptorsForProperty(
+            @NotNull PropertyDescriptor propertyDescriptor,
+            @NotNull LexicalScope scopeForResolution,
+            @NotNull BindingTrace trace,
+            @NotNull List<KtTypeReference> receiverTypeReferences,
+            @NotNull Map<ReceiverParameterDescriptor, String> receiverToLabelMap,
+            boolean isAdditional
+    ) {
+        Map<KtTypeReference, KotlinType> nonNullReceiverTypeReferencesToTypes = new HashMap<>();
+        List<KtTypeReference> nonNullReceiverTypeReferences = receiverTypeReferences.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        for (KtTypeReference typeReference: nonNullReceiverTypeReferences) {
+            KotlinType kotlinType = typeResolver.resolveType(scopeForResolution, typeReference, trace, true);
+            nonNullReceiverTypeReferencesToTypes.put(typeReference, kotlinType);
+        }
+        Stream<KtTypeReference> receiverTypeReferenceStream = Lists.reverse(nonNullReceiverTypeReferences).stream();
+        return receiverTypeReferenceStream.map(receiverTypeReference -> {
+            KotlinType receiverType = nonNullReceiverTypeReferencesToTypes.get(receiverTypeReference);
+            AnnotationSplitter splitter = new AnnotationSplitter(storageManager, receiverType.getAnnotations(), EnumSet.of(RECEIVER));
+            ReceiverParameterDescriptor receiverDescriptor = DescriptorFactory.createExtensionReceiverParameterForCallable(
+                    propertyDescriptor, receiverType, splitter.getAnnotationsForTarget(RECEIVER),
+                    isAdditional);
+            receiverToLabelMap.put(receiverDescriptor, receiverTypeReference.nameForReceiverLabel());
+            return receiverDescriptor;
+        }).collect(Collectors.toList());
     }
 
     @NotNull

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt
@@ -217,17 +217,14 @@ class FunctionDescriptorResolver(
             }
         }
 
-        val receiverToLabelMap = linkedMapOf<ReceiverParameterDescriptor, String>()
+        val receiverToLabelMap = linkedMapOf<ReceiverParameterDescriptor, String?>()
         val extensionReceiver = receiverType?.let {
             val splitter = AnnotationSplitter(storageManager, receiverType.annotations, EnumSet.of(AnnotationUseSiteTarget.RECEIVER))
             DescriptorFactory.createExtensionReceiverParameterForCallable(
                 functionDescriptor, it, splitter.getAnnotationsForTarget(AnnotationUseSiteTarget.RECEIVER), false
             )
         }?.apply {
-            val extensionReceiverName = receiverTypeRef?.nameForReceiverLabel()
-            if (extensionReceiverName != null) {
-                receiverToLabelMap[this] = extensionReceiverName
-            }
+            receiverToLabelMap[this] = receiverTypeRef?.nameForReceiverLabel()
         }
 
         val additionalReceivers = additionalReceiverTypes.mapNotNull { type ->
@@ -238,9 +235,7 @@ class FunctionDescriptorResolver(
         }
         additionalReceivers.reversed().forEachIndexed { i, additionalReceiver ->
             val additionalReceiverName = additionalReceiverTypeRefs[additionalReceiverTypeRefs.lastIndex - i].nameForReceiverLabel()
-            if (additionalReceiverName != null) {
-                receiverToLabelMap[additionalReceiver] = additionalReceiverName
-            }
+            receiverToLabelMap[additionalReceiver] = additionalReceiverName
         }
         trace.record(BindingContext.DESCRIPTOR_TO_NAMED_RECEIVERS, functionDescriptor, receiverToLabelMap)
         functionDescriptor.initialize(

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorUtil.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorUtil.java
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.resolve;
 
+import com.google.common.collect.Lists;
 import kotlin.Unit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.descriptors.*;
@@ -111,7 +112,8 @@ public class FunctionDescriptorUtil {
             implicitReceivers.add(extensionReceiverParameter);
         }
         if (!descriptor.getAdditionalReceiverParameters().isEmpty()) {
-            implicitReceivers.addAll(descriptor.getAdditionalReceiverParameters());
+            List<ReceiverParameterDescriptor> additionalReceivers = Lists.reverse(descriptor.getAdditionalReceiverParameters());
+            implicitReceivers.addAll(additionalReceivers);
         }
         return new LexicalScopeImpl(
                 outerScope, descriptor, true, implicitReceivers,

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt
@@ -425,11 +425,6 @@ class CandidateResolver(
             checkReceiverTypeError(extensionReceiver, candidateCall.extensionReceiver)
         }
         checkReceiverTypeError(dispatchReceiver, candidateCall.dispatchReceiver)
-
-        assert(additionalReceivers.size == candidateCall.additionalReceivers.size)
-        for (i in additionalReceivers.indices) {
-            checkReceiverTypeError(additionalReceivers[i], candidateCall.additionalReceivers[i])
-        }
     }
 
     private fun CallCandidateResolutionContext<*>.checkReceiverTypeError(

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt
@@ -176,7 +176,7 @@ internal fun getIdForStableIdentifier(
 
         is KtThisExpression -> {
             val declarationDescriptor = bindingContext.get(BindingContext.REFERENCE_TARGET, expression.instanceReference)
-            getIdForThisReceiver(declarationDescriptor, bindingContext, expression.getLabelName())
+            getIdForThisReceiver(declarationDescriptor, bindingContext, null, expression.getLabelName())
         }
 
         is KtPostfixExpression -> {
@@ -255,7 +255,7 @@ private fun getIdForImplicitReceiver(receiverValue: ReceiverValue?, expression: 
     when (receiverValue) {
         is ExpressionImplicitReceiver -> IdentifierInfo.NO
 
-        is ImplicitReceiver -> getIdForThisReceiver(receiverValue.declarationDescriptor, bindingContext)
+        is ImplicitReceiver -> getIdForThisReceiver(receiverValue.declarationDescriptor, bindingContext, receiverValue, null)
 
         is TransientReceiver ->
             throw AssertionError("Transient receiver is implicit for an explicit expression: $expression. Receiver: $receiverValue")
@@ -266,24 +266,25 @@ private fun getIdForImplicitReceiver(receiverValue: ReceiverValue?, expression: 
 private fun getIdForThisReceiver(
     descriptorOfThisReceiver: DeclarationDescriptor?,
     bindingContext: BindingContext,
-    labelName: String? = null
+    receiverValue: ReceiverValue?,
+    labelName: String?
 ) =
     when (descriptorOfThisReceiver) {
         is CallableDescriptor -> {
-            val receiverParameter = findReceiverByLabelOrGetDefault(
+            val receiverParameter = findReceiverByValueOrLabel(
                 descriptorOfThisReceiver,
-                descriptorOfThisReceiver.extensionReceiverParameter,
                 bindingContext,
+                receiverValue,
                 labelName
             )
             IdentifierInfo.Receiver(receiverParameter.value)
         }
 
         is ClassDescriptor -> {
-            val receiverParameter = findReceiverByLabelOrGetDefault(
+            val receiverParameter = findReceiverByValueOrLabel(
                 descriptorOfThisReceiver,
-                descriptorOfThisReceiver.thisAsReceiverParameter,
                 bindingContext,
+                receiverValue,
                 labelName
             )
             IdentifierInfo.Receiver(receiverParameter.value)
@@ -292,16 +293,24 @@ private fun getIdForThisReceiver(
         else -> IdentifierInfo.NO
     }
 
-private fun findReceiverByLabelOrGetDefault(
+private fun findReceiverByValueOrLabel(
     descriptorOfThisReceiver: DeclarationDescriptor,
-    default: ReceiverParameterDescriptor?,
     bindingContext: BindingContext,
-    labelName: String? = null
+    receiverValue: ReceiverValue?,
+    labelName: String?
 ): ReceiverParameterDescriptor {
-    val receiverToLabelMap = bindingContext.get(BindingContext.DESCRIPTOR_TO_NAMED_RECEIVERS, descriptorOfThisReceiver)
-    return receiverToLabelMap?.entries?.find {
-        it.value == labelName
-    }?.key ?: default ?: error("'This' refers to the callable member without a receiver parameter: $descriptorOfThisReceiver")
+    val receiverToLabelEntries = bindingContext.get(BindingContext.DESCRIPTOR_TO_NAMED_RECEIVERS, descriptorOfThisReceiver)?.entries
+    val receiverParameter = receiverToLabelEntries?.find {
+        val receiverParameter = it.key
+        val label = it.value
+        when {
+            receiverValue != null -> receiverParameter.value == receiverValue
+            labelName != null -> label == labelName
+            else -> false
+        }
+    } ?: receiverToLabelEntries?.firstOrNull()
+    return receiverParameter?.key
+        ?: error("'This' refers to the callable member without a receiver parameter: $descriptorOfThisReceiver")
 }
 
 

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt
@@ -270,21 +270,40 @@ private fun getIdForThisReceiver(
 ) =
     when (descriptorOfThisReceiver) {
         is CallableDescriptor -> {
-            val receiverToLabelMap = bindingContext.get(BindingContext.DESCRIPTOR_TO_NAMED_RECEIVERS, descriptorOfThisReceiver)
-            val receiverParameter = receiverToLabelMap?.entries?.find {
-                it.value == labelName
-            }?.key ?: descriptorOfThisReceiver.extensionReceiverParameter
-            ?: error("'This' refers to the callable member without a receiver parameter: $descriptorOfThisReceiver")
+            val receiverParameter = findReceiverByLabelOrGetDefault(
+                descriptorOfThisReceiver,
+                descriptorOfThisReceiver.extensionReceiverParameter,
+                bindingContext,
+                labelName
+            )
             IdentifierInfo.Receiver(receiverParameter.value)
         }
 
         is ClassDescriptor -> {
-            // TODO: Do something with additional receivers
-            IdentifierInfo.Receiver(descriptorOfThisReceiver.thisAsReceiverParameter.value)
+            val receiverParameter = findReceiverByLabelOrGetDefault(
+                descriptorOfThisReceiver,
+                descriptorOfThisReceiver.thisAsReceiverParameter,
+                bindingContext,
+                labelName
+            )
+            IdentifierInfo.Receiver(receiverParameter.value)
         }
 
         else -> IdentifierInfo.NO
     }
+
+private fun findReceiverByLabelOrGetDefault(
+    descriptorOfThisReceiver: DeclarationDescriptor,
+    default: ReceiverParameterDescriptor?,
+    bindingContext: BindingContext,
+    labelName: String? = null
+): ReceiverParameterDescriptor {
+    val receiverToLabelMap = bindingContext.get(BindingContext.DESCRIPTOR_TO_NAMED_RECEIVERS, descriptorOfThisReceiver)
+    return receiverToLabelMap?.entries?.find {
+        it.value == labelName
+    }?.key ?: default ?: error("'This' refers to the callable member without a receiver parameter: $descriptorOfThisReceiver")
+}
+
 
 private fun postfix(argumentInfo: IdentifierInfo, op: KtToken): IdentifierInfo =
     if (argumentInfo == IdentifierInfo.NO) IdentifierInfo.NO else IdentifierInfo.PostfixIdentifierInfo(argumentInfo, op)

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassDescriptor.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassDescriptor.java
@@ -52,10 +52,7 @@ import org.jetbrains.kotlin.storage.StorageManager;
 import org.jetbrains.kotlin.types.*;
 import org.jetbrains.kotlin.types.checker.KotlinTypeRefiner;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static kotlin.collections.CollectionsKt.firstOrNull;
@@ -63,6 +60,7 @@ import static org.jetbrains.kotlin.descriptors.DescriptorVisibilities.PRIVATE;
 import static org.jetbrains.kotlin.descriptors.DescriptorVisibilities.PUBLIC;
 import static org.jetbrains.kotlin.diagnostics.Errors.*;
 import static org.jetbrains.kotlin.lexer.KtTokens.INNER_KEYWORD;
+import static org.jetbrains.kotlin.resolve.BindingContext.DESCRIPTOR_TO_NAMED_RECEIVERS;
 import static org.jetbrains.kotlin.resolve.BindingContext.TYPE;
 import static org.jetbrains.kotlin.resolve.ModifiersChecker.resolveModalityFromModifiers;
 import static org.jetbrains.kotlin.resolve.ModifiersChecker.resolveVisibilityFromModifiers;
@@ -276,16 +274,23 @@ public class LazyClassDescriptor extends ClassDescriptorBase implements ClassDes
         // TODO: only consider classes from the same file, not the whole package fragment
         this.sealedSubclasses = storageManager.createLazyValue(() -> DescriptorUtilsKt.computeSealedSubclasses(this));
         this.additionalReceivers = storageManager.createLazyValue(() -> {
+            Map<ReceiverParameterDescriptor, String> receiverToLabelMap = new LinkedHashMap<>();
+            receiverToLabelMap.put(getThisAsReceiverParameter(), null);
+            c.getTrace().record(DESCRIPTOR_TO_NAMED_RECEIVERS, this, receiverToLabelMap);
             if (classOrObject == null) {
                 return CollectionsKt.emptyList();
             }
-            return classOrObject.getAdditionalReceiverTypeReferences().stream().map(typeReference -> {
+            return classOrObject.getAdditionalReceiverTypeReferences().stream()
+                    .filter(Objects::nonNull)
+                    .map(typeReference -> {
                 KotlinType kotlinType = c.getTypeResolver().resolveType(getScopeForClassHeaderResolution(), typeReference, c.getTrace(), true);
-                return new ReceiverParameterDescriptorImpl(
+                ReceiverParameterDescriptor receiverParameterDescriptor = new ReceiverParameterDescriptorImpl(
                         this,
                         new ExtensionClassReceiver(this, kotlinType, null),
                         Annotations.Companion.getEMPTY()
                 );
+                receiverToLabelMap.put(receiverParameterDescriptor, typeReference.nameForReceiverLabel());
+                return receiverParameterDescriptor;
             }).collect(Collectors.toList());
         });
     }

--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/BasicExpressionTypingVisitor.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/BasicExpressionTypingVisitor.java
@@ -66,6 +66,7 @@ import org.jetbrains.kotlin.resolve.constants.*;
 import org.jetbrains.kotlin.resolve.scopes.LexicalScopeKind;
 import org.jetbrains.kotlin.resolve.scopes.LexicalWritableScope;
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver;
+import org.jetbrains.kotlin.resolve.scopes.receivers.ExtensionReceiver;
 import org.jetbrains.kotlin.resolve.scopes.receivers.ReceiverValue;
 import org.jetbrains.kotlin.resolve.scopes.utils.ScopeUtilsKt;
 import org.jetbrains.kotlin.types.*;
@@ -588,7 +589,12 @@ public class BasicExpressionTypingVisitor extends ExpressionTypingVisitor {
                 }
             }
             else if (!receivers.isEmpty()) {
-                result = receivers.get(0);
+                for (ReceiverParameterDescriptor receiver : receivers) {
+                    if (!(receiver.getValue() instanceof ExtensionReceiver) || !((ExtensionReceiver) receiver.getValue()).isAdditional()) {
+                        result = receiver;
+                        break;
+                    }
+                }
             }
             if (result != null) {
                 context.trace.record(REFERENCE_TARGET, expression.getInstanceReference(), result.getContainingDeclaration());

--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt
@@ -27,18 +27,22 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.checkReservedYield
 import org.jetbrains.kotlin.resolve.*
-import org.jetbrains.kotlin.resolve.BindingContext.LABEL_TARGET
-import org.jetbrains.kotlin.resolve.BindingContext.REFERENCE_TARGET
+import org.jetbrains.kotlin.resolve.BindingContext.*
 import org.jetbrains.kotlin.resolve.calls.context.ResolutionContext
 import org.jetbrains.kotlin.resolve.scopes.utils.getDeclarationsByLabel
+import org.jetbrains.kotlin.utils.addIfNotNull
 
 object LabelResolver {
-    private fun getElementsByLabelName(labelName: Name, labelExpression: KtSimpleNameExpression): Set<KtElement> {
+    private fun getElementsByLabelName(
+        labelName: Name,
+        labelExpression: KtSimpleNameExpression,
+        isThisExpression: Boolean
+    ): Set<KtElement> {
         val elements = linkedSetOf<KtElement>()
         var parent: PsiElement? = labelExpression.parent
         while (parent != null) {
-            val name = getLabelNameIfAny(parent)
-            if (name != null && name == labelName) {
+            val names = getLabelNamesIfAny(parent, isThisExpression)
+            if (names.contains(labelName)) {
                 elements.add(getExpressionUnderLabel(parent as KtExpression))
             }
             parent = if (parent is KtCodeFragment) parent.context else parent.parent
@@ -46,20 +50,33 @@ object LabelResolver {
         return elements
     }
 
-    fun getLabelNameIfAny(element: PsiElement): Name? {
-        return when (element) {
-            is KtLabeledExpression -> element.getLabelNameAsName()
-            is KtFunctionLiteral -> getLabelNameIfAny(element.parent)
-            is KtLambdaExpression -> getLabelForFunctionalExpression(element)
-            is KtNamedFunction -> element.nameAsName ?: getLabelForFunctionalExpression(element)
-            else -> null
+    fun getLabelNamesIfAny(element: PsiElement, addAdditionalReceiverNames: Boolean): List<Name> {
+        val result = mutableListOf<Name>()
+        when (element) {
+            is KtLabeledExpression -> result.addIfNotNull(element.getLabelNameAsName())
+            // TODO: Support additional receivers in function literals
+            is KtFunctionLiteral -> return getLabelNamesIfAny(element.parent, false)
+            is KtLambdaExpression -> result.addIfNotNull(getLabelForFunctionalExpression(element))
         }
+        val functionOrProperty = when (element) {
+            is KtNamedFunction -> element
+            is KtPropertyAccessor -> element.property
+            else -> return result
+        }
+        if (addAdditionalReceiverNames) {
+            functionOrProperty.additionalReceiverTypeReferences
+                .mapNotNullTo(result) { it.nameForReceiverLabel()?.let { s -> Name.identifier(s) } }
+            functionOrProperty.receiverTypeReference?.nameForReceiverLabel()?.let { result.add(Name.identifier(it)) }
+        }
+        val name = functionOrProperty.nameAsName ?: getLabelForFunctionalExpression(functionOrProperty)
+        result.addIfNotNull(name)
+        return result
     }
 
     private fun getLabelForFunctionalExpression(element: KtExpression): Name? {
         val parent = element.parent
         return when (parent) {
-            is KtLabeledExpression -> getLabelNameIfAny(parent)
+            is KtLabeledExpression -> getLabelNamesIfAny(parent, false).singleOrNull()
             is KtBinaryExpression -> parent.operationReference.getReferencedNameAsName()
             else -> getCallerName(element)
         }
@@ -105,7 +122,7 @@ object LabelResolver {
         val labelName = expression.getLabelNameAsName()
         if (labelElement == null || labelName == null) return null
 
-        return resolveNamedLabel(labelName, labelElement, context.trace) ?: run {
+        return resolveNamedLabel(labelName, labelElement, context.trace, false) ?: run {
             context.trace.report(UNRESOLVED_REFERENCE.on(labelElement, labelElement))
             null
         }
@@ -114,9 +131,10 @@ object LabelResolver {
     private fun resolveNamedLabel(
         labelName: Name,
         labelExpression: KtSimpleNameExpression,
-        trace: BindingTrace
+        trace: BindingTrace,
+        isThisExpression: Boolean
     ): KtElement? {
-        val list = getElementsByLabelName(labelName, labelExpression)
+        val list = getElementsByLabelName(labelName, labelExpression, isThisExpression)
         if (list.isEmpty()) return null
 
         if (list.size > 1) {
@@ -160,10 +178,13 @@ object LabelResolver {
                 return LabeledReceiverResolutionResult.labelResolutionSuccess(thisReceiver)
             }
             0 -> {
-                val element = resolveNamedLabel(labelName, targetLabel, context.trace)
-                val declarationDescriptor = context.trace.bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, element]
+                val element = resolveNamedLabel(labelName, targetLabel, context.trace, expression is KtThisExpression)
+                val declarationDescriptor = context.trace.bindingContext[DECLARATION_TO_DESCRIPTOR, element]
                 if (declarationDescriptor is FunctionDescriptor) {
-                    val thisReceiver = declarationDescriptor.extensionReceiverParameter
+                    val receiverToLabelMap = context.trace.bindingContext[DESCRIPTOR_TO_NAMED_RECEIVERS, declarationDescriptor]
+                    val thisReceiver = receiverToLabelMap?.entries?.find {
+                        it.value == labelName.identifier
+                    }?.key ?: declarationDescriptor.extensionReceiverParameter
                     if (thisReceiver != null) {
                         context.trace.record(LABEL_TARGET, targetLabel, element)
                         context.trace.record(REFERENCE_TARGET, referenceExpression, declarationDescriptor)

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/StatementGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/StatementGenerator.kt
@@ -406,12 +406,16 @@ class StatementGenerator(
                 generateThisReceiver(startOffset, endOffset, referenceTarget.thisAsReceiverParameter.type, referenceTarget)
 
             is CallableDescriptor -> {
-                val extensionReceiver = referenceTarget.extensionReceiverParameter ?: TODO("No extension receiver: $referenceTarget")
-                val extensionReceiverType = extensionReceiver.type.toIrType()
+                val resolvedCall = getResolvedCall(expression)
+                val receivers = listOfNotNull(referenceTarget.extensionReceiverParameter) + referenceTarget.additionalReceiverParameters
+                val receiver = receivers.find {
+                    it == resolvedCall?.candidateDescriptor
+                } ?: TODO("No receiver: $referenceTarget")
+                val receiverType = receiver.type.toIrType()
                 IrGetValueImpl(
                     startOffset, endOffset,
-                    extensionReceiverType,
-                    context.symbolTable.referenceValueParameter(extensionReceiver)
+                    receiverType,
+                    context.symbolTable.referenceValueParameter(receiver)
                 )
             }
 

--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtTypeReference.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtTypeReference.kt
@@ -52,4 +52,6 @@ class KtTypeReference : KtModifierListOwnerStub<KotlinPlaceHolderStub<KtTypeRefe
     fun hasParentheses(): Boolean {
         return findChildByType<PsiElement>(KtTokens.LPAR) != null && findChildByType<PsiElement>(KtTokens.RPAR) != null
     }
+
+    fun nameForReceiverLabel() = if (typeElement is KtUserType) (typeElement as KtUserType).referencedName else null
 }

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tasks/synthesizedInvokes.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tasks/synthesizedInvokes.kt
@@ -70,7 +70,7 @@ private fun createSynthesizedFunctionWithFirstParameterAsReceiver(descriptor: Fu
     descriptor.original.newCopyBuilder().apply {
         setExtensionReceiverParameter(
             DescriptorFactory.createExtensionReceiverParameterForCallable(
-                descriptor.original, descriptor.original.valueParameters.first().type, Annotations.EMPTY
+                descriptor.original, descriptor.original.valueParameters.first().type, Annotations.EMPTY, false
             )
         )
         setValueParameters(

--- a/compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt
+++ b/compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt
@@ -1,0 +1,17 @@
+class A<T>(val a: T)
+class B(val b: Any?)
+
+with<A<String>, B> fun f() {
+    this@A.a.length
+    this@B.b
+}
+
+fun box(): String {
+    with(A("")) {
+        with(B(null)) {
+            f()
+        }
+    }
+    return "OK"
+}
+

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.fir.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.fir.kt
@@ -1,0 +1,19 @@
+interface Context {
+    fun h() {}
+}
+
+open class A {
+    open fun f() {}
+}
+
+class B : A() {
+    override fun f() {}
+
+    with<Context>
+    inner class C {
+        fun g() {
+            super@B.f()
+            super@Context.<!UNRESOLVED_REFERENCE!>h<!>()
+        }
+    }
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.kt
@@ -1,0 +1,19 @@
+interface Context {
+    fun h() {}
+}
+
+open class A {
+    open fun f() {}
+}
+
+class B : A() {
+    override fun f() {}
+
+    with<Context>
+    inner class C {
+        fun g() {
+            super@B.f()
+            <!DEBUG_INFO_MISSING_UNRESOLVED!>super<!><!UNRESOLVED_REFERENCE!>@Context<!>.<!DEBUG_INFO_MISSING_UNRESOLVED!>h<!>()
+        }
+    }
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.txt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.txt
@@ -1,0 +1,32 @@
+package
+
+public open class A {
+    public constructor A()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open fun f(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class B : A {
+    public constructor B()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ fun f(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    public final inner class C {
+        public constructor C()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public final fun g(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}
+
+public interface Context {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open fun h(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.fir.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.fir.kt
@@ -1,0 +1,9 @@
+class A {
+    val x = 1
+}
+
+with<A> class B {
+    val prop = <!UNRESOLVED_REFERENCE!>x<!> + <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>x<!>
+
+    fun f() = <!UNRESOLVED_REFERENCE!>x<!> + <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>x<!>
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.kt
@@ -1,0 +1,9 @@
+class A {
+    val x = 1
+}
+
+with<A> class B {
+    val prop = x + this<!UNRESOLVED_REFERENCE!>@A<!>.<!DEBUG_INFO_MISSING_UNRESOLVED!>x<!>
+
+    fun f() = x + this<!UNRESOLVED_REFERENCE!>@A<!>.<!DEBUG_INFO_MISSING_UNRESOLVED!>x<!>
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.txt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.txt
@@ -1,0 +1,18 @@
+package
+
+public final class A {
+    public constructor A()
+    public final val x: kotlin.Int = 1
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class B {
+    public constructor B()
+    public final val prop: [ERROR : Type for x + this@A.x]
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public final fun f(): [ERROR : Error function type]
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.fir.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.fir.kt
@@ -1,0 +1,6 @@
+class A(val a: String?)
+
+with<A> fun f() {
+    if (<!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>a<!> == null) return
+    <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>a<!>.<!UNRESOLVED_REFERENCE!>length<!>
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.kt
@@ -1,0 +1,6 @@
+class A(val a: String?)
+
+with<A> fun f() {
+    if (this@A.a == null) return
+    <!DEBUG_INFO_SMARTCAST!>this@A.a<!>.length
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.txt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.txt
@@ -1,0 +1,11 @@
+package
+
+public fun f(): kotlin.Unit
+
+public final class A {
+    public constructor A(/*0*/ a: kotlin.String?)
+    public final val a: kotlin.String?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.fir.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.fir.kt
@@ -1,0 +1,17 @@
+class A<T>(val a: T)
+class B(val b: Any)
+class C(val c: Any)
+
+with<A<Int>, A<String>, B> fun f() {
+    this@A.a.length
+    this@B.b
+    <!NO_THIS!>this<!>
+}
+
+with<A<Int>, A<String>, B> fun C.f() {
+    this@A.a.length
+    this@B.b
+    this@C.c
+    this@f.c
+    this.c
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.kt
@@ -1,0 +1,17 @@
+class A<T>(val a: T)
+class B(val b: Any)
+class C(val c: Any)
+
+with<A<Int>, A<String>, B> fun f() {
+    this@A.a.length
+    this@B.b
+    <!NO_THIS!>this<!>
+}
+
+with<A<Int>, A<String>, B> fun C.f() {
+    this@A.a.length
+    this@B.b
+    this@C.c
+    this@f.c
+    this.c
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.txt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.txt
@@ -1,0 +1,28 @@
+package
+
+public fun f(): kotlin.Unit
+public fun C.f(): kotlin.Unit
+
+public final class A</*0*/ T> {
+    public constructor A</*0*/ T>(/*0*/ a: T)
+    public final val a: T
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class B {
+    public constructor B(/*0*/ b: kotlin.Any)
+    public final val b: kotlin.Any
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class C {
+    public constructor C(/*0*/ c: kotlin.Any)
+    public final val c: kotlin.Any
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.fir.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.fir.kt
@@ -1,0 +1,28 @@
+class A<T>(val a: T)
+class B(val b: Any)
+class C(val c: Any)
+
+with<A<Int>, A<String>, B> var p: Int
+    get() {
+        <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>a<!>.<!UNRESOLVED_REFERENCE!>toDouble<!>()
+        <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>a<!>.<!UNRESOLVED_REFERENCE!>length<!>
+        <!UNRESOLVED_LABEL!>this@B<!>.<!UNRESOLVED_REFERENCE!>b<!>
+        <!NO_THIS!>this<!>
+        return 1
+    }
+    set(value) {
+        <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>a<!>.<!UNRESOLVED_REFERENCE!>length<!>
+        <!UNRESOLVED_LABEL!>this@B<!>.<!UNRESOLVED_REFERENCE!>b<!>
+        <!NO_THIS!>this<!>
+        field = value
+    }
+
+with<A<Int>, A<String>, B> val C.p: Int
+    get() {
+        <!UNRESOLVED_LABEL!>this@A<!>.<!UNRESOLVED_REFERENCE!>a<!>.<!UNRESOLVED_REFERENCE!>length<!>
+        <!UNRESOLVED_LABEL!>this@B<!>.<!UNRESOLVED_REFERENCE!>b<!>
+        <!UNRESOLVED_LABEL!>this@C<!>.<!UNRESOLVED_REFERENCE!>c<!>
+        this@p.c
+        this.c
+        return 1
+    }

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.kt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.kt
@@ -1,0 +1,28 @@
+class A<T>(val a: T)
+class B(val b: Any)
+class C(val c: Any)
+
+with<A<Int>, A<String>, B> var p: Int
+    get() {
+        this@A.a.<!UNRESOLVED_REFERENCE!>toDouble<!>()
+        this@A.a.length
+        this@B.b
+        <!NO_THIS!>this<!>
+        return 1
+    }
+    set(value) {
+        this@A.a.length
+        this@B.b
+        <!NO_THIS!>this<!>
+        <!UNRESOLVED_REFERENCE!>field<!> = value
+    }
+
+with<A<Int>, A<String>, B> val C.p: Int
+    get() {
+        this@A.a.length
+        this@B.b
+        this@C.c
+        this@p.c
+        this.c
+        return 1
+    }

--- a/compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.txt
+++ b/compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.txt
@@ -1,0 +1,28 @@
+package
+
+public var p: kotlin.Int
+public val C.p: kotlin.Int
+
+public final class A</*0*/ T> {
+    public constructor A</*0*/ T>(/*0*/ a: T)
+    public final val a: T
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class B {
+    public constructor B(/*0*/ b: kotlin.Any)
+    public final val b: kotlin.Any
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class C {
+    public constructor C(/*0*/ c: kotlin.Any)
+    public final val c: kotlin.Any
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
@@ -8144,6 +8144,37 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTestWithFirVali
                 runTest("compiler/testData/diagnostics/tests/extensions/variableInvoke.kt");
             }
 
+            @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class AdditionalReceiverObjects extends AbstractDiagnosticsTestWithFirValidation {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects"), Pattern.compile("^(.*)\\.kts?$"), Pattern.compile("^(.+)\\.fir\\.kts?$"), true);
+                }
+
+                @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions")
+                @TestDataPath("$PROJECT_ROOT")
+                @RunWith(JUnit3RunnerWithInners.class)
+                public static class Functions extends AbstractDiagnosticsTestWithFirValidation {
+                    private void runTest(String testDataFilePath) throws Exception {
+                        KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                    }
+
+                    public void testAllFilesPresentInFunctions() throws Exception {
+                        KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions"), Pattern.compile("^(.*)\\.kts?$"), Pattern.compile("^(.+)\\.fir\\.kts?$"), true);
+                    }
+
+                    @TestMetadata("simple.kt")
+                    public void testSimple() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions/simple.kt");
+                    }
+                }
+            }
+
             @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceivers")
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)
@@ -8177,6 +8208,16 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTestWithFirVali
                     public void testOuterClass() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/outerClass.kt");
                     }
+
+                    @TestMetadata("superWithContext.kt")
+                    public void testSuperWithContext() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.kt");
+                    }
+
+                    @TestMetadata("thisWithReceiverLabels.kt")
+                    public void testThisWithReceiverLabels() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.kt");
+                    }
                 }
 
                 @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions")
@@ -8196,6 +8237,11 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTestWithFirVali
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/insideDeclaration.kt");
                     }
 
+                    @TestMetadata("manyReceivers.kt")
+                    public void testManyReceivers() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/manyReceivers.kt");
+                    }
+
                     @TestMetadata("noExplicitReceiver.kt")
                     public void testNoExplicitReceiver() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/noExplicitReceiver.kt");
@@ -8204,6 +8250,21 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTestWithFirVali
                     @TestMetadata("plusMatrix.kt")
                     public void testPlusMatrix() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/plusMatrix.kt");
+                    }
+
+                    @TestMetadata("resolutionFailure.kt")
+                    public void testResolutionFailure() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/resolutionFailure.kt");
+                    }
+
+                    @TestMetadata("thisIdentifierInfo.kt")
+                    public void testThisIdentifierInfo() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.kt");
+                    }
+
+                    @TestMetadata("thisWithReceiverLabels.kt")
+                    public void testThisWithReceiverLabels() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.kt");
                     }
 
                     @TestMetadata("typeParameterized.kt")
@@ -8242,6 +8303,11 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTestWithFirVali
                     @TestMetadata("dp.kt")
                     public void testDp() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/dp.kt");
+                    }
+
+                    @TestMetadata("thisWithReceiverLabels.kt")
+                    public void testThisWithReceiverLabels() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.kt");
                     }
                 }
             }

--- a/compiler/tests/org/jetbrains/kotlin/checkers/javac/DiagnosticsUsingJavacTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/javac/DiagnosticsUsingJavacTestGenerated.java
@@ -8139,6 +8139,37 @@ public class DiagnosticsUsingJavacTestGenerated extends AbstractDiagnosticsUsing
                 runTest("compiler/testData/diagnostics/tests/extensions/variableInvoke.kt");
             }
 
+            @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class AdditionalReceiverObjects extends AbstractDiagnosticsUsingJavacTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), Pattern.compile("^(.+)\\.fir\\.kts?$"), true);
+                }
+
+                @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions")
+                @TestDataPath("$PROJECT_ROOT")
+                @RunWith(JUnit3RunnerWithInners.class)
+                public static class Functions extends AbstractDiagnosticsUsingJavacTest {
+                    private void runTest(String testDataFilePath) throws Exception {
+                        KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                    }
+
+                    public void testAllFilesPresentInFunctions() throws Exception {
+                        KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions"), Pattern.compile("^(.+)\\.kt$"), Pattern.compile("^(.+)\\.fir\\.kts?$"), true);
+                    }
+
+                    @TestMetadata("simple.kt")
+                    public void testSimple() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceiverObjects/functions/simple.kt");
+                    }
+                }
+            }
+
             @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceivers")
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)
@@ -8172,6 +8203,16 @@ public class DiagnosticsUsingJavacTestGenerated extends AbstractDiagnosticsUsing
                     public void testOuterClass() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/outerClass.kt");
                     }
+
+                    @TestMetadata("superWithContext.kt")
+                    public void testSuperWithContext() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/superWithContext.kt");
+                    }
+
+                    @TestMetadata("thisWithReceiverLabels.kt")
+                    public void testThisWithReceiverLabels() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/classes/thisWithReceiverLabels.kt");
+                    }
                 }
 
                 @TestMetadata("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions")
@@ -8191,6 +8232,11 @@ public class DiagnosticsUsingJavacTestGenerated extends AbstractDiagnosticsUsing
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/insideDeclaration.kt");
                     }
 
+                    @TestMetadata("manyReceivers.kt")
+                    public void testManyReceivers() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/manyReceivers.kt");
+                    }
+
                     @TestMetadata("noExplicitReceiver.kt")
                     public void testNoExplicitReceiver() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/noExplicitReceiver.kt");
@@ -8199,6 +8245,21 @@ public class DiagnosticsUsingJavacTestGenerated extends AbstractDiagnosticsUsing
                     @TestMetadata("plusMatrix.kt")
                     public void testPlusMatrix() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/plusMatrix.kt");
+                    }
+
+                    @TestMetadata("resolutionFailure.kt")
+                    public void testResolutionFailure() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/resolutionFailure.kt");
+                    }
+
+                    @TestMetadata("thisIdentifierInfo.kt")
+                    public void testThisIdentifierInfo() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisIdentifierInfo.kt");
+                    }
+
+                    @TestMetadata("thisWithReceiverLabels.kt")
+                    public void testThisWithReceiverLabels() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/functions/thisWithReceiverLabels.kt");
                     }
 
                     @TestMetadata("typeParameterized.kt")
@@ -8237,6 +8298,11 @@ public class DiagnosticsUsingJavacTestGenerated extends AbstractDiagnosticsUsing
                     @TestMetadata("dp.kt")
                     public void testDp() throws Exception {
                         runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/dp.kt");
+                    }
+
+                    @TestMetadata("thisWithReceiverLabels.kt")
+                    public void testThisWithReceiverLabels() throws Exception {
+                        runTest("compiler/testData/diagnostics/tests/extensions/additionalReceivers/properties/thisWithReceiverLabels.kt");
                     }
                 }
             }

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -13050,6 +13050,29 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -13067,14 +13090,39 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -13050,6 +13050,29 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractLightAnalysisModeTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -13067,14 +13090,39 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -11650,6 +11650,29 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractIrBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -11667,14 +11690,39 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/descriptors/JavaClassConstructorDescriptor.java
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/descriptors/JavaClassConstructorDescriptor.java
@@ -129,8 +129,8 @@ public class JavaClassConstructorDescriptor extends ClassConstructorDescriptorIm
                 getContainingDeclaration(), /* original = */ null, getKind(), null, getAnnotations(), getSource());
         ReceiverParameterDescriptor enhancedReceiver =
                 enhancedReceiverType == null ? null : DescriptorFactory.createExtensionReceiverParameterForCallable(
-                        enhanced, enhancedReceiverType, Annotations.Companion.getEMPTY()
-                );
+                        enhanced, enhancedReceiverType, Annotations.Companion.getEMPTY(),
+                        false);
         // We do not use doSubstitute here as in JavaMethodDescriptor.enhance because type parameters of constructor belongs to class
         enhanced.initialize(
                 enhancedReceiver, getDispatchReceiverParameter(), CollectionsKt.<ReceiverParameterDescriptor>emptyList(),

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/descriptors/JavaMethodDescriptor.java
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/descriptors/JavaMethodDescriptor.java
@@ -154,8 +154,8 @@ public class JavaMethodDescriptor extends SimpleFunctionDescriptorImpl implement
 
         ReceiverParameterDescriptor enhancedReceiver =
                 enhancedReceiverType == null ? null : DescriptorFactory.createExtensionReceiverParameterForCallable(
-                        this, enhancedReceiverType, Annotations.Companion.getEMPTY()
-                );
+                        this, enhancedReceiverType, Annotations.Companion.getEMPTY(),
+                        false);
 
         JavaMethodDescriptor enhancedMethod =
                 (JavaMethodDescriptor) newCopyBuilder()

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/descriptors/JavaPropertyDescriptor.java
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/descriptors/JavaPropertyDescriptor.java
@@ -154,8 +154,8 @@ public class JavaPropertyDescriptor extends PropertyDescriptorImpl implements Ja
 
         ReceiverParameterDescriptor enhancedReceiver =
                 enhancedReceiverType == null ? null : DescriptorFactory.createExtensionReceiverParameterForCallable(
-                        this, enhancedReceiverType, Annotations.Companion.getEMPTY()
-                );
+                        this, enhancedReceiverType, Annotations.Companion.getEMPTY(),
+                        false);
 
         enhanced.setType(
                 enhancedReturnType,

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt
@@ -168,7 +168,7 @@ abstract class LazyJavaScope(
 
         functionDescriptorImpl.initialize(
             effectiveSignature.receiverType?.let {
-                DescriptorFactory.createExtensionReceiverParameterForCallable(functionDescriptorImpl, it, Annotations.EMPTY)
+                DescriptorFactory.createExtensionReceiverParameterForCallable(functionDescriptorImpl, it, Annotations.EMPTY, false)
             },
             getDispatchReceiverParameter(),
             emptyList(),

--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/TypeAliasConstructorDescriptor.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/TypeAliasConstructorDescriptor.kt
@@ -198,7 +198,8 @@ class TypeAliasConstructorDescriptorImpl private constructor(
                 DescriptorFactory.createExtensionReceiverParameterForCallable(
                     typeAliasConstructor,
                     substitutorForUnderlyingClass.safeSubstitute(it.type, Variance.INVARIANT),
-                    Annotations.EMPTY
+                    Annotations.EMPTY,
+                    false
                 )
             }
 

--- a/core/descriptors/src/org/jetbrains/kotlin/resolve/DescriptorFactory.java
+++ b/core/descriptors/src/org/jetbrains/kotlin/resolve/DescriptorFactory.java
@@ -179,10 +179,11 @@ public class DescriptorFactory {
     public static ReceiverParameterDescriptor createExtensionReceiverParameterForCallable(
             @NotNull CallableDescriptor owner,
             @Nullable KotlinType receiverParameterType,
-            @NotNull Annotations annotations
+            @NotNull Annotations annotations,
+            boolean isAdditional
     ) {
         return receiverParameterType == null
                ? null
-               : new ReceiverParameterDescriptorImpl(owner, new ExtensionReceiver(owner, receiverParameterType, null), annotations);
+               : new ReceiverParameterDescriptorImpl(owner, new ExtensionReceiver(owner, receiverParameterType, null, isAdditional), annotations);
     }
 }

--- a/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/receivers/ExtensionReceiver.java
+++ b/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/receivers/ExtensionReceiver.java
@@ -35,14 +35,25 @@ import org.jetbrains.kotlin.types.checker.NewKotlinTypeChecker;
 public class ExtensionReceiver extends AbstractReceiverValue implements ImplicitReceiver {
 
     private final CallableDescriptor descriptor;
+    private final boolean isAdditional;
 
     public ExtensionReceiver(
             @NotNull CallableDescriptor callableDescriptor,
             @NotNull KotlinType receiverType,
             @Nullable ReceiverValue original
     ) {
+        this(callableDescriptor, receiverType, original, false);
+    }
+
+    public ExtensionReceiver(
+            @NotNull CallableDescriptor callableDescriptor,
+            @NotNull KotlinType receiverType,
+            @Nullable ReceiverValue original,
+            boolean isAdditional
+    ) {
         super(receiverType, original);
         this.descriptor = callableDescriptor;
+        this.isAdditional = isAdditional;
     }
 
     @NotNull
@@ -60,5 +71,9 @@ public class ExtensionReceiver extends AbstractReceiverValue implements Implicit
     @Override
     public String toString() {
         return getType() + ": Ext {" + descriptor + "}";
+    }
+
+    public boolean isAdditional() {
+        return isAdditional;
     }
 }

--- a/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt
+++ b/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt
@@ -63,7 +63,7 @@ class MemberDeserializer(private val c: DeserializationContext) {
             local.typeDeserializer.ownTypeParameters,
             getDispatchReceiverParameter(),
             proto.receiverType(c.typeTable)?.let(local.typeDeserializer::type)?.let { receiverType ->
-                DescriptorFactory.createExtensionReceiverParameterForCallable(property, receiverType, receiverAnnotations)
+                DescriptorFactory.createExtensionReceiverParameterForCallable(property, receiverType, receiverAnnotations, false)
             },
             emptyList()
         )
@@ -278,7 +278,7 @@ class MemberDeserializer(private val c: DeserializationContext) {
 
         function.initializeWithCoroutinesExperimentalityStatus(
             proto.receiverType(c.typeTable)?.let(local.typeDeserializer::type)?.let { receiverType ->
-                DescriptorFactory.createExtensionReceiverParameterForCallable(function, receiverType, receiverAnnotations)
+                DescriptorFactory.createExtensionReceiverParameterForCallable(function, receiverType, receiverAnnotations, false)
             },
             getDispatchReceiverParameter(),
             local.typeDeserializer.ownTypeParameters,

--- a/idea/jvm-debugger/jvm-debugger-evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/DebuggerFieldSyntheticScopeProvider.kt
+++ b/idea/jvm-debugger/jvm-debugger-evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/DebuggerFieldSyntheticScopeProvider.kt
@@ -183,7 +183,8 @@ class DebuggerFieldSyntheticScope(val javaSyntheticPropertiesScope: JavaSyntheti
         val extensionReceiverParameter = DescriptorFactory.createExtensionReceiverParameterForCallable(
             propertyDescriptor,
             clazz.defaultType.replaceArgumentsWithStarProjections(),
-            Annotations.EMPTY
+            Annotations.EMPTY,
+            false
         )
 
         propertyDescriptor.setType(

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -9985,6 +9985,29 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractIrJsCodegenBoxES6Test {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR_ES6, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -10002,14 +10025,39 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -9985,6 +9985,29 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractIrJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -10002,14 +10025,39 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -9985,6 +9985,29 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/extensionFunctions/whenFail.kt");
         }
 
+        @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AdditionalReceiverObjects extends AbstractJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAdditionalReceiverObjects() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
+            }
+
+            @TestMetadata("anyContext.kt")
+            public void testAnyContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/anyContext.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceiverObjects/simple.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/extensionFunctions/additionalReceivers")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -10002,14 +10025,39 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/dp.kt");
             }
 
+            @TestMetadata("greedyResolution.kt")
+            public void testGreedyResolution() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/greedyResolution.kt");
+            }
+
+            @TestMetadata("manyReceivers.kt")
+            public void testManyReceivers() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/manyReceivers.kt");
+            }
+
+            @TestMetadata("maxWithComparator.kt")
+            public void testMaxWithComparator() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/maxWithComparator.kt");
+            }
+
             @TestMetadata("plusMatrix.kt")
             public void testPlusMatrix() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/plusMatrix.kt");
             }
 
+            @TestMetadata("printInContext.kt")
+            public void testPrintInContext() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/printInContext.kt");
+            }
+
             @TestMetadata("simpleCall.kt")
             public void testSimpleCall() throws Exception {
                 runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/simpleCall.kt");
+            }
+
+            @TestMetadata("this.kt")
+            public void testThis() throws Exception {
+                runTest("compiler/testData/codegen/box/extensionFunctions/additionalReceivers/this.kt");
             }
         }
     }

--- a/native/commonizer/src/org/jetbrains/kotlin/descriptors/commonizer/builder/builderUtils.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/descriptors/commonizer/builder/builderUtils.kt
@@ -79,7 +79,8 @@ internal fun CirExtensionReceiver.buildExtensionReceiver(
 ) = DescriptorFactory.createExtensionReceiverParameterForCallable(
     containingDeclaration,
     type.buildType(targetComponents, typeParameterResolver),
-    annotations.buildDescriptors(targetComponents)
+    annotations.buildDescriptors(targetComponents),
+    false
 )
 
 internal fun buildDispatchReceiver(callableDescriptor: CallableDescriptor) =

--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/syntheticDescriptorGeneration.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/syntheticDescriptorGeneration.kt
@@ -48,7 +48,7 @@ internal fun genClearCacheFunction(packageFragmentDescriptor: PackageFragmentDes
 
     val unitType = packageFragmentDescriptor.builtIns.unitType
     return function.initialize(
-        DescriptorFactory.createExtensionReceiverParameterForCallable(function, receiverType, Annotations.EMPTY),
+        DescriptorFactory.createExtensionReceiverParameterForCallable(function, receiverType, Annotations.EMPTY, false),
         null,
         emptyList(),
         emptyList(),
@@ -129,7 +129,7 @@ private fun genProperty(
         flexibleType,
         emptyList<TypeParameterDescriptor>(),
         null,
-        DescriptorFactory.createExtensionReceiverParameterForCallable(property, receiverType, Annotations.EMPTY),
+        DescriptorFactory.createExtensionReceiverParameterForCallable(property, receiverType, Annotations.EMPTY, false),
         emptyList<ReceiverParameterDescriptor>()
     )
 


### PR DESCRIPTION
1) `this@<referencedName>` is generated for the main receiver
2) `this@<referencedName>` is generated for every additional receiver
3) If there is no main receiver, `this` is not available inside the top-level function